### PR TITLE
Latest mongodb results in errors. Use image: mongo:5.0.11

### DIFF
--- a/manifests/backend-services/orders-db/orders-db.yml
+++ b/manifests/backend-services/orders-db/orders-db.yml
@@ -42,7 +42,7 @@ spec:
         product: sockshop
     spec:
       containers:
-      - image: mongo
+      - image: mongo:5.0.11
         name: orders-db
         env:
         - name: MONGODB_ADMIN_PASSWORD
@@ -122,7 +122,7 @@ spec:
         product: sockshop
     spec:
       containers:
-      - image: mongo
+      - image: mongo:5.0.11
         name: orders-db
         env:
         - name: MONGODB_ADMIN_PASSWORD


### PR DESCRIPTION
Latest mongodb results in errors(add to car wouldn't work). 

Use 
image: mongo:5.0.11
instead of 
image: mongo
Typical error seen in the backend:

Query failed with error code 352 and error message 'Unsupported OP_QUERY command: find. The client driver may require an upgrade. For more details see https://dochub.mongodb.org/core/legacy-opcode-...